### PR TITLE
Habilidad SeguirAlMouse

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -93,16 +93,12 @@ pilas.iniciar({ancho: 320, alto: 240, data_path: 'data'});
 
 pilas.onready = function() {
   var fondo = new pilas.fondos.Plano();
+
   window.aceituna = new pilas.actores.Aceituna();
+  window.aceituna.aprender(pilas.habilidades.SeguirAlMouse);
+
   window.bomba = new pilas.actores.Bomba();
   window.bomba.x = 50;
-
-  var mover_aceituna = function (evento) {
-    window.aceituna.x = evento.x;
-    window.aceituna.y = evento.y;
-  }
-
-  pilas.escena_actual().mueve_mouse.conectar(mover_aceituna);
 
   //window.actor = new pilas.actores.Actor();
   //window.aceituna.x = [100, 0, 100, 0];

--- a/public/pilasweb.js
+++ b/public/pilasweb.js
@@ -447,8 +447,13 @@ var Evento = (function () {
         this.nombre = nombre;
     }
     Evento.prototype.emitir = function (evento) {
-        for(var respuesta in this.respuestas) {
-            this.respuestas[respuesta](evento);
+        for(var nombre_respuesta in this.respuestas) {
+            var respuesta = this.respuestas[nombre_respuesta];
+            if(typeof (respuesta) == 'object') {
+                respuesta.recibir(evento, this);
+            } else {
+                respuesta(evento);
+            }
         }
     };
     Evento.prototype.conectar = function (respuesta) {
@@ -538,6 +543,29 @@ var PuedeExplotar = (function (_super) {
     return PuedeExplotar;
 })(Habilidad);
 /**
+* @class SeguirAlMouse
+*
+* Hace que un actor siga la posición del mouse en todo momento.
+*/
+var SeguirAlMouse = (function (_super) {
+    __extends(SeguirAlMouse, _super);
+    function SeguirAlMouse(receptor) {
+        _super.call(this, receptor);
+        pilas.escena_actual().mueve_mouse.conectar(this);
+    }
+    SeguirAlMouse.prototype.recibir = function (evento, tipo) {
+        if(tipo == pilas.escena_actual().mueve_mouse) {
+            this.mover(evento);
+        }
+    };
+    SeguirAlMouse.prototype.mover = function (evento) {
+        console.log(this);
+        this.receptor.x = evento.x;
+        this.receptor.y = evento.y;
+    };
+    return SeguirAlMouse;
+})(Habilidad);
+/**
 * @class Habilidades
 *
 * Representa todas las habilidades conocidas en pilas-engine.
@@ -545,6 +573,7 @@ var PuedeExplotar = (function (_super) {
 var Habilidades = (function () {
     function Habilidades() {
         this.PuedeExplotar = PuedeExplotar;
+        this.SeguirAlMouse = SeguirAlMouse;
     }
     return Habilidades;
 })();

--- a/src/evento.ts
+++ b/src/evento.ts
@@ -8,8 +8,14 @@ class Evento {
   }
 
   public emitir(evento) {
-    for (var respuesta in this.respuestas) {
-      this.respuestas[respuesta](evento);
+    for (var nombre_respuesta in this.respuestas) {
+      var respuesta = this.respuestas[nombre_respuesta];
+      if (typeof(respuesta) == 'object') {
+        respuesta.recibir(evento, this);
+      }
+      else {
+        respuesta(evento);
+      }
     }
   }
 

--- a/src/habilidades.ts
+++ b/src/habilidades.ts
@@ -37,6 +37,30 @@ class PuedeExplotar extends Habilidad {
 }
 
 /**
+ * @class SeguirAlMouse
+ *
+ * Hace que un actor siga la posición del mouse en todo momento.
+ */
+class SeguirAlMouse extends Habilidad {
+  constructor(receptor) {
+    super(receptor);
+    pilas.escena_actual().mueve_mouse.conectar(this);
+  }
+
+  recibir(evento, tipo) {
+    if (tipo == pilas.escena_actual().mueve_mouse) {
+      this.mover(evento);
+    }
+  }
+
+  mover(evento) {
+    console.log(this);
+    this.receptor.x = evento.x;
+    this.receptor.y = evento.y;
+  }
+}
+
+/**
  * @class Habilidades
  *
  * Representa todas las habilidades conocidas en pilas-engine.
@@ -44,8 +68,10 @@ class PuedeExplotar extends Habilidad {
 class Habilidades {
 
   PuedeExplotar;
+  SeguirAlMouse;
 
   constructor() {
     this.PuedeExplotar = PuedeExplotar;
+    this.SeguirAlMouse = SeguirAlMouse;
   }
 }


### PR DESCRIPTION
Hugo, intenté seguir con las habilidades y me bloqueé un poco al conectarlas a los eventos.  En Python hay proxies como ProxyMetodo para esto.  La solución que encontré, como se ve en este pull-request, es pasarle la habilidad al evento, y luego al emitirlo se llama al método "recibir" de la habilidad.  Quizá hay una forma más adecuada.
