### PR TITLE
Añadido parametro actor_o_array a la clase Grupo

### DIFF
--- a/src/grupo.ts
+++ b/src/grupo.ts
@@ -24,8 +24,15 @@ class HGrupo {
 HGrupo["prototype"] = new Array();
 
 class Grupo extends HGrupo {
-	constructor() {
+	constructor(actor_o_array) {
 		super();
+		if (actor_o_array instanceof Array) {
+			this.agregar_grupo(actor_o_array)
+		}
+
+		else if (actor_o_array instanceof Object) {
+			this.agregar_actor(actor_o_array)
+		}
 	}
 
 	agregar_grupo(grupo) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ class Utils {
 
   fabricar(clase, cantidad=1, posiciones_al_azar=true) { //Mover a ../actores/utils.ts
 
-    var grupo = new pilas.grupo.Grupo();
+    var actores = []
 
     for (var i=0;i<cantidad;i++) {
       if (posiciones_al_azar) {
@@ -45,9 +45,9 @@ class Utils {
       }
 
       var nuevo = new clase(x, y);
-      grupo.agregar_actor(nuevo);
+      actores.push(nuevo);
     }
     
-    return grupo;
+    return new pilas.grupo.Grupo(actores);
   }
 }


### PR DESCRIPTION
Podemos crear una instancia de la clase Grupo con su contenido definido, por ejemplo:

```
var aceitunas = [new pilas.actores.Aceituna(),new pilas.actores.Aceituna(),new pilas.actores.Aceituna()];
var aceituna = new pilas.actores.Aceituna();


var grupo_vacio = new pilas.grupo.Grupo(); 
var aceitunas_grupo = new pilas.grupo.Grupo(aceitunas);
var aceituna_grupo = new pilas.grupo.Grupo(aceituna);
```
