### PR TITLE
Eliminando console.log()

### DIFF
--- a/src/sonidos.ts
+++ b/src/sonidos.ts
@@ -32,7 +32,6 @@ class Sonidos {
 
 	private cargar_recurso(nombre) {
 		this.recursos.push({id:nombre, src:nombre});
-		console.log("cargando " + nombre);
 	}
 
 	public cargar(nombre) {


### PR DESCRIPTION
Eliminando console.log() que informaba sobre los archivos de sonido que se cargaban.
