### PR TITLE
Agregado el método eliminar a la clase Figura del motor de Físicas

### DIFF
--- a/src/actores/actor.ts
+++ b/src/actores/actor.ts
@@ -111,6 +111,9 @@ class Actor extends Estudiante {
   eliminar() {
     this.vivo = false;
     pilas.escena_actual().eliminar_actor(this);
+    if (this.tiene_fisica()) {
+      this.figura.eliminar();
+    }
   }
 
   get z() {

--- a/src/fisica.ts
+++ b/src/fisica.ts
@@ -112,6 +112,11 @@ class Figura {
       return convertir_a_pixels(shape.GetRadius());
     }
   }
+
+  eliminar() {
+    this.fisica.mundo.DestroyBody(this.cuerpo);
+  }
+
 }
 
 


### PR DESCRIPTION
Al momento de eliminar un actor que estuviera imitando una figura física existía el bug que la figura física seguía en el escenario, con este método se corrige.
