### PR TITLE
Obteniendo ancho y alto del actor en base al area visible de la imagen

### DIFF
--- a/src/actores/actor.ts
+++ b/src/actores/actor.ts
@@ -205,8 +205,22 @@ class Actor extends Estudiante {
   get transparencia() {return (-100 * this.sprite.alpha) + 100}
   set transparencia(_t) {this.sprite.alpha = (_t - 100) / -100}
 
-  get ancho() {return this._imagen.ancho}
-  get alto() {return this._imagen.alto}
+  get ancho() {
+    if (this._imagen instanceof Grilla) {
+      return this._imagen.ancho/this._imagen.columnas
+    }
+    else {
+      return this._imagen.ancho;
+    }
+  }
+  get alto() {
+    if (this._imagen instanceof Grilla) {
+      return this._imagen.alto/this._imagen.filas
+    }
+    else {
+      return this._imagen.alto;
+    }
+  }
 
   set imagen(_i) {
     if (_i.substring)


### PR DESCRIPTION
Si el actor recibe cómo imagen una grilla definimos su ancho y alto en base a las columnas o filas que la dividan.
