### PR TITLE
Gruntfile: typescript, modificando propiedades para compatibilidad

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,8 +45,8 @@ module.exports = function(grunt) {
         options: {
           module: 'commonjs',
           target: 'es5',
-          base_path: 'src',
-          sourcemap: false,
+          basePath: 'src',
+          sourceMap: false,
           fullSourceMapPath: false,
           declaration: false,
           comments: true,


### PR DESCRIPTION
Aparecía este mensaje al compilar: 'The 'base_path' option will be obsoleted. Please use the 'basePath''

Los nombres de las propiedades cambiaron en la última versión de grunt-typescript https://www.npmjs.org/package/grunt-typescript

Para evitar futuros problemas, modifique los nombres.
