### PR TITLE
BugFix caminarBase + BugFix Texto

### DIFF
--- a/public/pilasweb.js
+++ b/public/pilasweb.js
@@ -16020,19 +16020,14 @@ var CaminarBase = (function (_super) {
         this.receptor = receptor;
         this.pasos = this.argumentos.pasos || 1;
         this.velocidad = 1;
-    };
-
-    CaminarBase.prototype.redondear = function (number) {
-        return parseFloat(number.toPrecision(8));
+        var pasitos = 0.05;
+        this.cantActualizaciones = Math.round(this.pasos / pasitos);
     };
 
     CaminarBase.prototype.actualizar = function () {
         this.mover();
-        var pasito = 0.05;
-        this.pasos -= pasito;
-        this.pasos = this.redondear(this.pasos); //TO DO: Esto no hay que hacerlo acá porque introduce mucho lag y estaría bueno que se haga una sola vez al principio de todo.
-
-        if (this.pasos < pasito) {
+        this.cantActualizaciones--;
+        if (this.cantActualizaciones < 1) {
             this.receptor.detener_animacion();
             return true;
         }

--- a/public/pilasweb.js
+++ b/public/pilasweb.js
@@ -13542,6 +13542,15 @@ var Actor = (function (_super) {
         configurable: true
     });
 
+    Actor.prototype.escalarProporcionalALimites = function (anchoLimite, altoLimite) {
+        var escalaAlto = this.alto / altoLimite;
+        var escalaAncho = this.ancho / anchoLimite;
+
+        var escalaMayor = Math.max(escalaAncho, escalaAlto);
+
+        this.escala = 1.0 / escalaMayor;
+    };
+
     Object.defineProperty(Actor.prototype, "rotacion", {
         get: function () {
             return -this.sprite.rotation;
@@ -16018,12 +16027,8 @@ var CaminarBase = (function (_super) {
     CaminarBase.prototype.actualizar = function () {
         this.mover();
         var pasito = 0.05;
-
-        //this.pasos -= pasito;
         this.pasos -= pasito;
-        this.pasos = this.redondear(this.pasos);
-
-        console.log(this.pasos);
+        this.pasos = this.redondear(this.pasos); //TO DO: Esto no hay que hacerlo acá porque introduce mucho lag y estaría bueno que se haga una sola vez al principio de todo.
 
         if (this.pasos < pasito) {
             this.receptor.detener_animacion();
@@ -17622,11 +17627,14 @@ var Texto = (function (_super) {
     }
     Texto.prototype.crear_texto = function () {
         var s = new createjs.Text(this.texto, "12px Arial", this.color);
+        s.lineWidth = 2;
+
+        this.alto = s.heightscale;
         var pos = pilas.escena_actual().obtener_posicion_pantalla(this.x, this.y);
         s.x = pos.x;
         s.y = pos.y;
-        s.textBaseline = "bottom";
-        s.textAlign = "center";
+        s.textBaseline = "alphabetic";
+        s.textAlign = "right";
         pilas.escena_actual().stage.addChild(s);
         this.sprite_texto = s;
     };
@@ -17639,58 +17647,6 @@ var Texto = (function (_super) {
         this.eliminar_texto();
         _super.prototype.eliminar.call(this);
     };
-
-    Object.defineProperty(Texto.prototype, "escala_x", {
-        //TODO: hacer que pueda utilizar los metodos propios de la clase padre Actor
-        get: function () {
-            return this.sprite_texto.scaleX;
-        },
-        set: function (valor) {
-            if (valor instanceof Array)
-                pilas.interpolar(this.sprite_texto, 'scaleX', valor, 1000);
-            else
-                this.sprite_texto.scaleX = valor;
-        },
-        enumerable: true,
-        configurable: true
-    });
-
-    Object.defineProperty(Texto.prototype, "escala_y", {
-        get: function () {
-            return this.sprite_texto.scaleY;
-        },
-        set: function (valor) {
-            if (valor instanceof Array)
-                pilas.interpolar(this.sprite_texto, 'scaleY', valor, 1000);
-            else
-                this.sprite_texto.scaleY = valor;
-        },
-        enumerable: true,
-        configurable: true
-    });
-
-    Object.defineProperty(Texto.prototype, "escala", {
-        get: function () {
-            return this.escala_x;
-        },
-        set: function (valor) {
-            if (valor instanceof Array) {
-                var nuevo_radio_de_colision = [];
-                for (var i = 0; i < valor.length; i++) {
-                    nuevo_radio_de_colision.push((this.radio_de_colision * valor[i]) / this.escala);
-                }
-                pilas.interpolar(this, 'radio_de_colision', nuevo_radio_de_colision, 1000);
-                this.radio_de_colision = nuevo_radio_de_colision[0];
-            } else {
-                this.radio_de_colision = (this.radio_de_colision * valor) / this.escala;
-            }
-
-            this.escala_x = valor;
-            this.escala_y = valor;
-        },
-        enumerable: true,
-        configurable: true
-    });
     return Texto;
 })(Actor);
 /// <reference path="actor.ts"/>

--- a/public/pilasweb.js
+++ b/public/pilasweb.js
@@ -16011,11 +16011,21 @@ var CaminarBase = (function (_super) {
         this.velocidad = 1;
     };
 
+    CaminarBase.prototype.redondear = function (number) {
+        return parseFloat(number.toPrecision(8));
+    };
+
     CaminarBase.prototype.actualizar = function () {
         this.mover();
-        this.pasos -= 0.05;
+        var pasito = 0.05;
 
-        if (this.pasos <= 0.05) {
+        //this.pasos -= pasito;
+        this.pasos -= pasito;
+        this.pasos = this.redondear(this.pasos);
+
+        console.log(this.pasos);
+
+        if (this.pasos < pasito) {
             this.receptor.detener_animacion();
             return true;
         }

--- a/public/pilasweb.js
+++ b/public/pilasweb.js
@@ -13543,6 +13543,8 @@ var Actor = (function (_super) {
     });
 
     Actor.prototype.escalarProporcionalALimites = function (anchoLimite, altoLimite) {
+        this.escala = 1;
+
         var escalaAlto = this.alto / altoLimite;
         var escalaAncho = this.ancho / anchoLimite;
 

--- a/src/actores/actor.ts
+++ b/src/actores/actor.ts
@@ -271,6 +271,8 @@ class Actor extends Estudiante {
   }
   
   escalarProporcionalALimites(anchoLimite,altoLimite){
+  		this.escala = 1;
+  		
         var escalaAlto = this.alto / altoLimite;
         var escalaAncho = this.ancho / anchoLimite;
         

--- a/src/actores/actor.ts
+++ b/src/actores/actor.ts
@@ -269,6 +269,15 @@ class Actor extends Estudiante {
     this.escala_x = valor;
     this.escala_y = valor;
   }
+  
+  escalarProporcionalALimites(anchoLimite,altoLimite){
+        var escalaAlto = this.alto / altoLimite;
+        var escalaAncho = this.ancho / anchoLimite;
+        
+        var escalaMayor = Math.max(escalaAncho,escalaAlto);
+
+        this.escala = 1.0 / escalaMayor;
+  }
 
   get rotacion() {return -this.sprite.rotation}
   set rotacion(valor:any) {

--- a/src/actores/texto.ts
+++ b/src/actores/texto.ts
@@ -17,14 +17,20 @@ class Texto extends Actor {
   }
 
   crear_texto() {
+
     var s = new createjs.Text(this.texto, "12px Arial", this.color);
+    s.lineWidth=2;
+
+
+    this.alto=s.heightscale;
     var pos = pilas.escena_actual().obtener_posicion_pantalla(this.x, this.y);
     s.x = pos.x;
     s.y = pos.y;
-    s.textBaseline = "bottom";
-    s.textAlign = "center";
+    s.textBaseline = "alphabetic";
+    s.textAlign = "right";
     pilas.escena_actual().stage.addChild(s);
     this.sprite_texto = s;
+
   }
 
   eliminar_texto() {
@@ -36,39 +42,5 @@ class Texto extends Actor {
     super.eliminar();
   }
 
-  //TODO: hacer que pueda utilizar los metodos propios de la clase padre Actor
-  get escala_x() {return this.sprite_texto.scaleX}
-  set escala_x(valor) {
-    if (valor instanceof Array)
-      pilas.interpolar(this.sprite_texto, 'scaleX', valor, 1000);
-    else
-      this.sprite_texto.scaleX = valor;
-  }
 
-  get escala_y() {return this.sprite_texto.scaleY}
-  set escala_y(valor) {
-    if (valor instanceof Array)
-      pilas.interpolar(this.sprite_texto, 'scaleY', valor, 1000);
-    else
-      this.sprite_texto.scaleY = valor;
-  }
-
-  get escala() {return this.escala_x}
-  set escala(valor) {
-
-    if (valor instanceof Array) {
-      var nuevo_radio_de_colision = []
-      for (var i=0; i<valor.length; i++) {
-        nuevo_radio_de_colision.push((this.radio_de_colision * valor[i]) / this.escala);
-      }
-      pilas.interpolar(this, 'radio_de_colision', nuevo_radio_de_colision, 1000);
-      this.radio_de_colision = nuevo_radio_de_colision[0];
-    }
-    else {
-      this.radio_de_colision = (this.radio_de_colision * valor) / this.escala;
-    }
-
-    this.escala_x = valor;
-    this.escala_y = valor;
-  }
 }

--- a/src/actores/texto.ts
+++ b/src/actores/texto.ts
@@ -19,7 +19,6 @@ class Texto extends Actor {
   crear_texto() {
 
     var s = new createjs.Text(this.texto, "12px Arial", this.color);
-    s.lineWidth=2;
 
 
     this.alto=s.heightscale;

--- a/src/comportamientos.ts
+++ b/src/comportamientos.ts
@@ -232,12 +232,18 @@ class CaminarBase extends Comportamiento {
     this.velocidad = 1;
   }
 
+  redondear(number) {
+      return parseFloat(number.toPrecision(8));
+   }
+
   actualizar() {
     this.mover();
-    this.pasos -= 0.05;
+    var pasito = 0.05;
+    this.pasos -= pasito;
+    this.pasos = this.redondear(this.pasos); //TO DO: Esto no hay que hacerlo acá porque introduce mucho lag y estaría bueno que se haga una sola vez al principio de todo.
 
-    if (this.pasos <= 0.05) { // TODO: en realidad tendría que ser 0.0 en vez de 0.1, pero por algún motivo siempre avanza un pixel mas...
-      this.receptor.detener_animacion()
+    if (this.pasos < pasito) {
+        this.receptor.detener_animacion();
       return true;
     }
   }

--- a/src/comportamientos.ts
+++ b/src/comportamientos.ts
@@ -225,25 +225,21 @@ class OrbitarSobreActor extends Orbitar {
 class CaminarBase extends Comportamiento {
   pasos;
   velocidad;
+  cantActualizaciones;
 
   iniciar(receptor) {
     this.receptor = receptor;
     this.pasos = this.argumentos.pasos || 1;
     this.velocidad = 1;
+    var pasitos = 0.05; //Cuanto mas chico es el valor pasitos, mas veces se actualiza el caminar.
+    this.cantActualizaciones = Math.round(this.pasos / pasitos);
   }
-
-  redondear(number) {
-      return parseFloat(number.toPrecision(8));
-   }
 
   actualizar() {
     this.mover();
-    var pasito = 0.05;
-    this.pasos -= pasito;
-    this.pasos = this.redondear(this.pasos); //TO DO: Esto no hay que hacerlo acá porque introduce mucho lag y estaría bueno que se haga una sola vez al principio de todo.
-
-    if (this.pasos < pasito) {
-        this.receptor.detener_animacion();
+    this.cantActualizaciones--;
+    if(this.cantActualizaciones < 1){
+      this.receptor.detener_animacion();
       return true;
     }
   }


### PR DESCRIPTION
1) CaminarBase tenía un problema con la precisión de punto flotante. Ahora usamos enteros.

2) El actor se puede escalarProporcionalmente si lo queremos meter dentro de ciertos límites (por ejemplo, una casilla).

3) Se borraron los métodos de escala y posicionamiento de Texto.ts para que herede los de Actor.ts.
